### PR TITLE
Mitigate spurious errors when doing developer install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,15 @@ line-length = 120
 target-version = ['py37']
 skip-string-normalization = true
 
+# * Setuptools 50.0 is fundamentally broken in numerous ways (including ways
+#   that both break and do not break installation of this project) and *MUST*
+#   thus be blacklisted. See also:
+#   https://github.com/pypa/setuptools/issues/2350
+#   https://github.com/pypa/setuptools/issues/2352
+#   https://github.com/pypa/setuptools/issues/2353
 [build-system]
-requires = ["poetry>=0.12"]
+requires = [
+        "poetry>=0.12",
+        'setuptools!=50.0'
+]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Workaround for ` ModuleNotFoundError: No module named 'setuptools'` error  when doing `pip install -e .` for local development.  

Appears to be due to interactions between `pyproject.toml` and pip etc.  See this [setuptools issue comment (and others)](https://github.com/pypa/setuptools/issues/2353#issuecomment-684094780).

For reference, here's the error I encountered:

```bash
python3 -m pip install -e .
Obtaining file:///home/inactivist/m/src/other/arq-narq/narq
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Installing collected packages: narq
  Running setup.py develop for narq
    ERROR: Command errored out with exit status 1:
     command: /home/inactivist/.virtualenvs/narq/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/inactivist/m/src/other/arq-narq/narq/setup.py'"'"'; __file__='"'"'/home/inactivist/m/src/other/arq-narq/narq/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps
         cwd: /home/inactivist/m/src/other/arq-narq/narq/
    Complete output (3 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'
    ----------------------------------------
ERROR: Command errored out with exit status 1: /home/inactivist/.virtualenvs/narq/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/inactivist/m/src/other/arq-narq/narq/setup.py'"'"'; __file__='"'"'/home/inactivist/m/src/other/arq-narq/narq/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps Check the logs for full command output.
```

